### PR TITLE
Support for custom dataobjects managed via a gridfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ class YourSEODataObject extends DataObject
 ### Add SEO SeoSiteTreeExtension as an extension to your DataObject
 We now need to extend your current object to utilise the SeoSiteTreeExtension, you can do this in two ways:
 
-1. Add extension directly to your object:
+#### Add extension directly to your object:
 
 ```php
 
@@ -158,7 +158,7 @@ class YourSEODataObject extends DataObject
 }
 ```
 
-2. Add extension via config.yml
+#### Add extension via config.yml
 
 ```
 YourSEODataObject:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,81 @@ Please use tag 1.1 in old sites with the old config and tag 2.0 for new projects
 ## Installation
 Place the module dir in your website root and run /dev/build?flush=all
 
+## Using custom DataObjects
+If you have created a custom data object that you want to make SEO friendly (for examnple Products in
+a commerce system) then you can by following these steps:
+
+### Ensure you have the correct fields
+In order for this module works correctly, your object will need the following DB fields:
+
+* Title
+* Content
+* URLSegment
+* MetaDescription
+
+
+### Add a getSiteConfig method to your dataobject.
+The SEO module needs to access the SiteConfig associated with the current object, so you need to ensure you add the
+following to your object class (this is taken directly from SiteTree.
+
+```php
+
+class YourSEODataObject extends DataObject
+{
+
+    ...
+    
+    /**
+	 * Stub method to get the site config, unless the current class can provide an alternate.
+	 *
+	 * @return SiteConfig
+	 */
+	public function getSiteConfig() {
+
+		if($this->hasMethod('alternateSiteConfig')) {
+			$altConfig = $this->alternateSiteConfig();
+			if($altConfig) return $altConfig;
+		}
+
+		return SiteConfig::current_site_config();
+	}
+    
+    ...
+}
+```
+
+### Add SEO SeoSiteTreeExtension as an extension to your DataObject
+We now need to extend your current object to utilise the SeoSiteTreeExtension, you can do this in two ways:
+
+1. Add extension directly to your object:
+
+```php
+
+class YourSEODataObject extends DataObject
+{
+
+    ...
+    
+    private static $extensions = array(
+        "SeoSiteTreeExtension"
+    );
+    
+    ...
+}
+```
+
+2. Add extension via config.yml
+
+```
+YourSEODataObject:
+  extensions:
+    - SeoSiteTreeExtension
+```
+
+### Re-build database and flush
+Finally run a dev/build?flush=1 and then ensure you flush the admin interface (with ?flush=1).
+
+
 ## TODO's for next versions
 
 - [ ] Check img tags for title and alt tags

--- a/code/GoogleSuggestField.php
+++ b/code/GoogleSuggestField.php
@@ -10,14 +10,21 @@ class GoogleSuggestField extends FormField
         Requirements::customScript(<<<JS
 
  			(function($) {
+				var edit_form_id = "Form_EditForm";
+				var alt_edit_form_id = "Form_ItemEditForm";
 
 				$.entwine('ss', function($){
 
 					$('.cms-edit-form input#Form_EditForm_{$this->getName()}').entwine({
 						// Constructor: onmatch
 						onmatch : function() {
+							if (!$("#" + edit_form_id ).length) {
+								edit_form_id = alt_edit_form_id;
+							}
 
-							$( "#Form_EditForm_{$this->getName()}" ).autocomplete({
+							console.log("#" + edit_form_id + "_{$this->getName()}");
+
+							$( "#" + edit_form_id + "_{$this->getName()}" ).autocomplete({
 								source: function( request, response ) {
 									$.ajax({
 									  url: "//suggestqueries.google.com/complete/search",

--- a/javascript/seo.js
+++ b/javascript/seo.js
@@ -1,10 +1,14 @@
 (function($) {
 
+	var edit_form_id = "Form_EditForm";
+	var alt_edit_form_id = "Form_ItemEditForm";
+
 	$.entwine('ss', function($){
 
 		$('input[name="MetaTitle"], textarea[name="MetaDescription"], input[name="SEOPageSubject"]').entwine({
 			// Constructor: onmatch
 			onmatch: function(){
+				set_edit_form_id();
 				set_preview_google_search_result();
 				calc_score_n_tips();
 			},
@@ -15,6 +19,7 @@
 			},
 			// extra: for live update on selecting a suggestion
 			onchange : function() {
+				set_edit_form_id();
 				set_preview_google_search_result();
 				calc_score_n_tips();
 			},
@@ -27,6 +32,14 @@
 		set_preview_google_search_result();
 		calc_score_n_tips();
 	});
+
+	// Check if the edit form is what we think it is (or a gridfield)
+	function set_edit_form_id() {
+		console.log($("#" + edit_form_id ).length);
+		if (!$("#" + edit_form_id ).length) {
+			edit_form_id = alt_edit_form_id;
+		}
+	}
 	
 	function calc_score_n_tips() {
 
@@ -59,11 +72,11 @@
 
 		var page_url_basehref = $('input[name="URLSegment"]').attr('data-prefix'),
 			page_url_segment = $('input[name="URLSegment"]').val(),
-			page_title       = ($('#Form_EditForm_MetaTitle').val() || $('#Form_EditForm_Title').val()),
-			page_menutitle  = $('#Form_EditForm_MenuTitle').val(),
-			page_content     = $('textarea#Form_EditForm_Content').val(),
-			page_metadata_title = $('#Form_EditForm_MetaTitle').val(),
-			page_metadata_description = $('#Form_EditForm_MetaDescription').val(),
+			page_title       = ($('#' + edit_form_id + '_MetaTitle').val() || $('#' + edit_form_id + '_Title').val()),
+			page_menutitle  = $('#' + edit_form_id + '_MenuTitle').val(),
+			page_content     = $('textarea#' + edit_form_id + '_Content').val(),
+			page_metadata_title = $('#' + edit_form_id + '_MetaTitle').val(),
+			page_metadata_description = $('#' + edit_form_id + '_MetaDescription').val(),
 			siteconfig_title = $('#ss_siteconfig_title').html();
 
 			// build google search preview
@@ -96,8 +109,8 @@
 		// get references to all relevant form fields;
 		var SEOPageSubject = $('input[name="SEOPageSubject"]').val().toLowerCase();
 		var PageTitle = $('input[name="Title"]').val().toLowerCase();
-		var EditorContent = (tinyMCE.getInstanceById("Form_EditForm_Content")!==undefined? // already initiated, else take field value (upon first load)
-				tinyMCE.getInstanceById("Form_EditForm_Content").getContent() :
+		var EditorContent = (tinyMCE.getInstanceById(edit_form_id + "_Content")!==undefined? // already initiated, else take field value (upon first load)
+				tinyMCE.getInstanceById(edit_form_id + "_Content").getContent() :
 						$('textarea[name="Content"]').val());
 				//console.log(EditorContent);
 		var FirstParagraph = $(EditorContent).filter('p').first().text().toLowerCase();

--- a/javascript/seo.js
+++ b/javascript/seo.js
@@ -35,7 +35,6 @@
 
 	// Check if the edit form is what we think it is (or a gridfield)
 	function set_edit_form_id() {
-		console.log($("#" + edit_form_id ).length);
 		if (!$("#" + edit_form_id ).length) {
 			edit_form_id = alt_edit_form_id;
 		}


### PR DESCRIPTION
It is not to hard to allow custom DataObjects to be accessible via unique URL's, but these may beed to be SEO friendly (for example Products in a commerce system).

These amends allow most of the functionality (with the exception of the suggestion field, which does not seem to load the custom JS via gridfield) to apply to custom DataObjects.