### PR TITLE
Change CSS and JS dependencies to allow autoloading

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,6 +1,14 @@
 ---
 Name: 'seoextensions'
 ---
+
+# Include required CSS and JS
+LeftAndMain:
+  extra_requirements_css:
+    - liveseo/css/seo.css
+  extra_requirements_javascript:
+    - liveseo/javascript/seo.js
+
 SiteTree:
   extensions:
     - 'SeoSiteTreeExtension'

--- a/code/GoogleSuggestField.php
+++ b/code/GoogleSuggestField.php
@@ -7,47 +7,7 @@ class GoogleSuggestField extends FormField
     
     public function Field($properties = array())
     {
-        Requirements::customScript(<<<JS
-
- 			(function($) {
-				var edit_form_id = "Form_EditForm";
-				var alt_edit_form_id = "Form_ItemEditForm";
-
-				$.entwine('ss', function($){
-
-					$('.cms-edit-form input#Form_EditForm_{$this->getName()}').entwine({
-						// Constructor: onmatch
-						onmatch : function() {
-							if (!$("#" + edit_form_id ).length) {
-								edit_form_id = alt_edit_form_id;
-							}
-
-							console.log("#" + edit_form_id + "_{$this->getName()}");
-
-							$( "#" + edit_form_id + "_{$this->getName()}" ).autocomplete({
-								source: function( request, response ) {
-									$.ajax({
-									  url: "//suggestqueries.google.com/complete/search",
-									  dataType: "jsonp",
-									  data: {
-										  client: 'firefox',
-									    q: request.term
-									  },
-									  success: function( data ) {
-									    response( data[1] );
-									  }
-									});
-								},
-								minLength: 3
-							});
-	
-						},
-					});
-				});
-
-			})(jQuery);
-JS
-);
+        Requirements::javascript(SEO_DIR . "/javascript/googlesuggestfield.js");
 
         $this->addExtraClass('text');
 

--- a/code/SeoSiteConfigExtension.php
+++ b/code/SeoSiteConfigExtension.php
@@ -9,8 +9,6 @@ class SeoSiteConfigExtension extends DataExtension
 
     public function updateCMSFields(FieldList $fields)
     {
-        Requirements::css(SEO_DIR.'/css/seo.css');
-
         // check for Google Sitemaps module & notification;
         $GSMactive = Config::inst()->get('GoogleSitemap', 'enabled', Config::INHERITED);
         $GSMping = Config::inst()->get('GoogleSitemap', 'google_notification_enabled', Config::INHERITED);

--- a/code/SeoSiteTreeExtension.php
+++ b/code/SeoSiteTreeExtension.php
@@ -51,21 +51,14 @@ class SeoSiteTreeExtension extends SiteTreeExtension
                 Config::inst()->get("SeoSiteTreeExtension", "excluded_page_types"))) {
             return;
         }
-
-        Requirements::css(SEO_DIR.'/css/seo.css');
-        //Requirements::javascript(SEO_DIR.'/javascript/seo.js');
-
         // Get title template
         $sc = SiteConfig::current_site_config();
+        
         if ($sc->SEOTitleTemplate) {
             $TitleTemplate = $sc->SEOTitleTemplate;
         } else {
-            $TitleTemplate = "page_title + ' &raquo; ' + siteconfig_title";
+            $TitleTemplate = "";
         }
-
-        $jsvars = array(
-            "TitleTemplate" => $TitleTemplate,
-        );
 
         // check if the page being checked provides images and links information
         $providedInfoFIeld = null;
@@ -94,8 +87,6 @@ class SeoSiteTreeExtension extends SiteTreeExtension
             }
         }
 
-        Requirements::javascriptTemplate(SEO_DIR.'/javascript/seo.js', $jsvars);
-
         // lets create a new tab on top
         $fields->addFieldsToTab('Root.SEO', array(
             LiteralField::create('googlesearchsnippetintro',
@@ -104,6 +95,8 @@ class SeoSiteTreeExtension extends SiteTreeExtension
                     '<div id="google_search_snippet"></div>'),
             LiteralField::create('siteconfigtitle',
                     '<div id="ss_siteconfig_title">' . $this->owner->getSiteConfig()->Title . '</div>'),
+            LiteralField::create('seotitletemplate',
+                    '<div id="ss_seo_title_template">' . $TitleTemplate . '</div>'),
         ));
 
         // move Metadata field from Root.Main to SEO tab for visualising direct impact on search result

--- a/css/seo.css
+++ b/css/seo.css
@@ -30,8 +30,9 @@
 	font-weight: normal;
 }
 
-/* hidden literal field for site title */
-#ss_siteconfig_title {
+/* hidden literal fields for site title */
+#ss_siteconfig_title,
+#ss_seo_title_template {
 	display: none;
 }
 
@@ -86,9 +87,7 @@ ul#seo_score_tips li {
 	background-color: green;
 	color: white;
 	padding: 1px 6px;
-	margin-top: 2px;
-	-webkit-border-radius: 3px; 
-	-moz-border-radius: 3px; 
+	margin-top: 2px; 
 	border-radius: 3px; 
 }
 .subjtest_no {

--- a/javascript/googlesuggestfield.js
+++ b/javascript/googlesuggestfield.js
@@ -1,0 +1,34 @@
+(function($) {
+    var edit_form_id = "Form_EditForm";
+    var alt_edit_form_id = "Form_ItemEditForm";
+
+    $.entwine('liveseo', function($){
+        $('.cms-edit-form input.googlesuggest').entwine({
+            // Constructor: onmatch
+            onmatch : function() {
+                if (!$("#" + edit_form_id ).length) {
+                    edit_form_id = alt_edit_form_id;
+                }
+
+                var field_id = $(this).attr("ID");
+
+                $( "#"+ field_id ).autocomplete({
+                    source: function( request, response ) {
+                        $.ajax({
+                            url: "//suggestqueries.google.com/complete/search",
+                            dataType: "jsonp",
+                            data: {
+                                client: 'firefox',
+                                q: request.term
+                            },
+                            success: function( data ) {
+                                response( data[1] );
+                            }
+                        });
+                    },
+                    minLength: 3
+                });
+            },
+        });
+    });
+})(jQuery);

--- a/javascript/seo.js
+++ b/javascript/seo.js
@@ -79,7 +79,10 @@
 			siteconfig_title = $('#ss_siteconfig_title').html();
 
 			// build google search preview
-			var google_search_title = $TitleTemplate;
+			var google_search_title = $("#ss_seo_title_template").val();
+			if(google_search_title.length	== 0) {
+				google_search_title = page_title + " &raquo; " + siteconfig_title;
+			}
 			var google_search_url = page_url_basehref + page_url_segment;
 			var google_search_description = page_metadata_description;
 


### PR DESCRIPTION
At the moment I very often have to refresh the page in the CMS to get the Javascript to load. This appears to be dues to the fact that the JS is loaded as "customscript" or "javascripttemplate" (so written into the page).

These changes move the JS libs to being required by LeftAndMain (and so they will be included by default and added to combined files) or in the case of GoogleSuggestField move to using a standard Requirements::javascript call (which causes the JS to be loaded via ajax).

I have tested these changes on a vanilla SilverStripe install and everything works as expected (both on SiteTree objects and on custom DataObjects) with no refreshing required.